### PR TITLE
Fix missing modules

### DIFF
--- a/deephedging/requirements.txt
+++ b/deephedging/requirements.txt
@@ -1,3 +1,10 @@
 cdxbasics >= 0.2.24
-tensorflow >= 2.11
+numpy >= 1.23
+scipy >= 1.15
+matplotlib >= 3.10
+ipython >= 8
+psutil >= 5.9
+sortedcontainers >= 2.4
+cvxpy
+tensorflow >= 2.17
 tensorflow_probability >= 0.19


### PR DESCRIPTION
## Summary
- add needed third-party packages to requirements.txt

## Testing
- `pip install -r deephedging/requirements.txt`
- `python - <<'PY'
import deephedging.world as dw
from deephedging.base import Config
c = Config()
w = dw.SimpleWorld_Spot_ATM(c)
print('nSamples', w.nSamples)
print('nSteps', w.nSteps)
PY`

------
https://chatgpt.com/codex/tasks/task_e_684e619b4e648321a695eb7c6e5d2f00