### PR TITLE
Fix missing wrap_config in trainer

### DIFF
--- a/deephedging/trainer.py
+++ b/deephedging/trainer.py
@@ -17,6 +17,7 @@ from cdxbasics.prettydict import PrettyDict as pdct
 from cdxbasics.util import uniqueHash
 from cdxbasics.config import Config
 from cdxbasics.subdir import SubDir, uniqueFileName48, CacheMode
+from collections.abc import Mapping
 import time as time
 import numpy as np # NOQA
 import psutil as psutil
@@ -471,6 +472,15 @@ class CdxConfigWrapper:
     def copy(self):
         # ✅ これを追加！
         return CdxConfigWrapper(self._config.copy())
+
+
+def wrap_config(obj):
+    """Recursively wrap dictionaries or Config objects with CdxConfigWrapper."""
+    if isinstance(obj, CdxConfigWrapper):
+        return obj
+    if isinstance(obj, Mapping) or isinstance(obj, Config):
+        return CdxConfigWrapper({k: wrap_config(v) for k, v in obj.items()})
+    return obj
 
 
 


### PR DESCRIPTION
## Summary
- implement `wrap_config` in trainer
- import `Mapping` to support wrapper

## Testing
- `python -m py_compile deephedging/trainer.py`

------
https://chatgpt.com/codex/tasks/task_e_684e65a5607c8321bf6869b81c7173ad